### PR TITLE
Add convenient methods for HTTP verbs

### DIFF
--- a/AFHTTPClient+RACSupport.h
+++ b/AFHTTPClient+RACSupport.h
@@ -29,6 +29,8 @@
 
 @interface AFHTTPClient (RACSupport)
 
+#pragma mark -
+
 // Enqueues an AFHTTPRequestOperation and returns a signal.
 //
 // requestOperation - The request operation to enqueue.
@@ -62,5 +64,62 @@
 // The returned signal sends a tuple of ((AFHTTPRequestOperation *)operation,
 // (id)responseObject) for each completed request, then completes.
 - (RACSignal *)rac_enqueueBatchOfHTTPRequestOperationsWithRequests:(NSArray *)urlRequests;
+
+#pragma mark -
+
+// Creates an AFHTTPRequestOperation with a `GET` request,
+// and enqueues it to the HTTP client's operation queue,
+// and then returns a signal
+//
+// path - The path to be appended to the HTTP client's base URL and used as the request URL.
+// parameters - The parameters to be encoded and set in the request HTTP body.
+//
+// The returned signal sends a tuple of ((AFHTTPRequestOperation *)operation,
+// (id)responseObject) for each completed request, then completes.
+- (RACSignal *)rac_getPath:(NSString *)path parameters:(NSDictionary *)parameters;
+
+// Creates an AFHTTPRequestOperation with a `POST` request,
+// and enqueues it to the HTTP client's operation queue,
+// and then returns a signal
+//
+// path - The path to be appended to the HTTP client's base URL and used as the request URL.
+// parameters - The parameters to be encoded and set in the request HTTP body.
+//
+// The returned signal sends a tuple of ((AFHTTPRequestOperation *)operation,
+// (id)responseObject) for each completed request, then completes.
+- (RACSignal *)rac_postPath:(NSString *)path parameters:(NSDictionary *)parameters;
+
+// Creates an AFHTTPRequestOperation with a `PUT` request,
+// and enqueues it to the HTTP client's operation queue,
+// and then returns a signal
+//
+// path - The path to be appended to the HTTP client's base URL and used as the request URL.
+// parameters - The parameters to be encoded and set in the request HTTP body.
+//
+// The returned signal sends a tuple of ((AFHTTPRequestOperation *)operation,
+// (id)responseObject) for each completed request, then completes.
+- (RACSignal *)rac_putPath:(NSString *)path parameters:(NSDictionary *)parameters;
+
+// Creates an AFHTTPRequestOperation with a `DELETE` request,
+// and enqueues it to the HTTP client's operation queue,
+// and then returns a signal
+//
+// path - The path to be appended to the HTTP client's base URL and used as the request URL.
+// parameters - The parameters to be encoded and set in the request HTTP body.
+//
+// The returned signal sends a tuple of ((AFHTTPRequestOperation *)operation,
+// (id)responseObject) for each completed request, then completes.
+- (RACSignal *)rac_deletePath:(NSString *)path parameters:(NSDictionary *)parameters;
+
+// Creates an AFHTTPRequestOperation with a `PATCH` request,
+// and enqueues it to the HTTP client's operation queue,
+// and then returns a signal
+//
+// path - The path to be appended to the HTTP client's base URL and used as the request URL.
+// parameters - The parameters to be encoded and set in the request HTTP body.
+//
+// The returned signal sends a tuple of ((AFHTTPRequestOperation *)operation,
+// (id)responseObject) for each completed request, then completes.
+- (RACSignal *)rac_patchPath:(NSString *)path parameters:(NSDictionary *)parameters;
 
 @end

--- a/AFHTTPClient+RACSupport.m
+++ b/AFHTTPClient+RACSupport.m
@@ -29,6 +29,8 @@
 
 @implementation AFHTTPClient (RACSupport)
 
+#pragma mark - 
+
 - (RACSignal *)rac_enqueueHTTPRequestOperation:(AFHTTPRequestOperation *)requestOperation
 {
     RACReplaySubject *subject = [RACReplaySubject replaySubjectWithCapacity:1];
@@ -62,6 +64,41 @@
         return [self HTTPRequestOperationWithRequest:urlRequest success:NULL failure:NULL];
     }] array];
     return [self rac_enqueueBatchOfHTTPRequestOperations:requestOperations];
+}
+
+#pragma mark -
+
+- (RACSignal *)rac_getPath:(NSString *)path parameters:(NSDictionary *)parameters
+{
+    return [self rac_enqueueRequestWithMethod:@"GET" path:path parameters:parameters];
+}
+
+- (RACSignal *)rac_postPath:(NSString *)path parameters:(NSDictionary *)parameters
+{
+    return [self rac_enqueueRequestWithMethod:@"POST" path:path parameters:parameters];
+}
+
+- (RACSignal *)rac_putPath:(NSString *)path parameters:(NSDictionary *)parameters
+{
+    return [self rac_enqueueRequestWithMethod:@"PUT" path:path parameters:parameters];
+}
+
+- (RACSignal *)rac_deletePath:(NSString *)path parameters:(NSDictionary *)parameters
+{
+    return [self rac_enqueueRequestWithMethod:@"DELETE" path:path parameters:parameters];
+}
+
+- (RACSignal *)rac_patchPath:(NSString *)path parameters:(NSDictionary *)parameters
+{
+    return [self rac_enqueueRequestWithMethod:@"PATCH" path:path parameters:parameters];
+}
+
+- (RACSignal *)rac_enqueueRequestWithMethod:(NSString *)method
+                                       path:(NSString *)path
+                                 parameters:(NSDictionary *)parameters
+{
+    NSURLRequest *request = [self requestWithMethod:method path:path parameters:parameters];
+    return [self rac_enqueueHTTPRequestOperationWithRequest:request];
 }
 
 @end

--- a/README.md
+++ b/README.md
@@ -58,6 +58,12 @@ AFNetworking-ReactiveCocoa adds these methods:
 - (RACSignal *)rac_enqueueBatchOfHTTPRequestOperations:(NSArray *)requestOperations;
 - (RACSignal *)rac_enqueueBatchOfHTTPRequestOperationsWithRequests:(NSArray *)urlRequests;
 
+- (RACSignal *)rac_getPath:(NSString *)path parameters:(NSDictionary *)parameters;
+- (RACSignal *)rac_postPath:(NSString *)path parameters:(NSDictionary *)parameters;
+- (RACSignal *)rac_putPath:(NSString *)path parameters:(NSDictionary *)parameters;
+- (RACSignal *)rac_deletePath:(NSString *)path parameters:(NSDictionary *)parameters;
+- (RACSignal *)rac_patchPath:(NSString *)path parameters:(NSDictionary *)parameters;
+
 @end
 
 @interface AFHTTPRequestOperation (RACSupport)


### PR DESCRIPTION
Implements the same style methods with AFHTTPClient's original `getPath:parameters:success:failure:` and so on.
